### PR TITLE
Robust parsing and clamping of client coordinates on connect

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -9,11 +9,26 @@ type ConnectionState = {
 
 export class Globe extends Server {
   onConnect(conn: Connection<ConnectionState>, ctx: ConnectionContext) {
-    const latitude = Number(ctx.request.cf?.latitude ?? Math.random() * 180 - 90);
-    const longitude = Number(ctx.request.cf?.longitude ?? Math.random() * 360 - 180);
+    const parseCoordinate = (value: unknown, fallback: number) => {
+      if (typeof value === "string" && value.trim() === "") {
+        return fallback;
+      }
+
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+
+    const randomLatitude = Math.random() * 180 - 90;
+    const randomLongitude = Math.random() * 360 - 180;
+    const latitude = parseCoordinate(ctx.request.cf?.latitude, randomLatitude);
+    const longitude = parseCoordinate(ctx.request.cf?.longitude, randomLongitude);
+    const location: Location = [
+      Math.max(-90, Math.min(90, latitude)),
+      Math.max(-180, Math.min(180, longitude)),
+    ];
 
     conn.setState({
-      location: [latitude, longitude],
+      location,
     });
 
     this.broadcastGlobe();


### PR DESCRIPTION
### Motivation
- Handle malformed, empty, or non-finite Cloudflare coordinate inputs so clients don't get invalid locations.
- Provide deterministic random fallbacks when coordinates are missing and avoid unintentionally treating empty strings as valid zeros.
- Ensure stored locations respect geographic bounds to prevent out-of-range values from propagating to clients.

### Description
- Add a `parseCoordinate` helper to coerce inputs to finite numbers and treat empty strings as missing values.
- Generate `randomLatitude` and `randomLongitude` fallbacks and use them when CF values are missing or invalid.
- Clamp latitude to `[-90, 90]` and longitude to `[-180, 180]` and store the clamped `location` in `conn.setState`.
- No changes were made to the broadcasting logic in `broadcastGlobe` beyond using the new `location` value.

### Testing
- Ran the TypeScript type-check with `tsc --noEmit` and it completed successfully.
- Ran the test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a08a8a6c8322a6475d48c3d33e90)