### PR TITLE
Configure PartySocket host/protocol and add connection logging in GlobeComponent

### DIFF
--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -10,9 +10,31 @@ function App() {
   const positions = useRef<Map<string, Location>>(new Map());
   const ownId = useRef<string | null>(null);
 
+  const partykitHost = import.meta.env.PUBLIC_PARTYKIT_HOST;
+  const socketHost =
+    typeof window === "undefined" ? (partykitHost ?? "localhost") : (partykitHost ?? window.location.host);
+  const socketProtocol =
+    typeof window === "undefined" ? "wss" : (window.location.protocol === "https:" ? "wss" : "ws");
+
   usePartySocket({
+    host: socketHost,
+    protocol: socketProtocol,
+    path: "/parties",
     room: "default",
     party: "globe",
+    onOpen() {
+      console.info("[PartySocket] Connected to globe/default");
+    },
+    onClose(event) {
+      console.warn("[PartySocket] Disconnected from globe/default", {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+      });
+    },
+    onError(event) {
+      console.error("[PartySocket] Connection error for globe/default", event);
+    },
     onMessage(evt) {
       if (typeof evt.data !== "string") {
         return;


### PR DESCRIPTION
### Motivation

- Make the party socket connection configurable for different deployment hosts and protocols and improve observability around socket lifecycle events.

### Description

- Read `PUBLIC_PARTYKIT_HOST` from `import.meta.env` and derive `socketHost` and `socketProtocol` to support server-side and client-side resolution.
- Pass explicit `host`, `protocol`, and `path` (`"/parties"`) options into `usePartySocket` so the socket endpoint can be customized. 
- Add `onOpen`, `onClose`, and `onError` handlers that log connection lifecycle details for easier debugging while preserving the existing `onMessage` behavior.

### Testing

- Ran TypeScript compilation (`tsc`) and the type-check passed. 
- Ran the project's automated test suite (`npm test`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a089e2b083228ef5eff078aa519d)