### PR TITLE
Document worker/DO/websocket architecture in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,37 +6,105 @@ A fun site for CareerLimitingManeuver.com, built with [Astro](https://astro.buil
 - ASCII art for terminal/curl visitors
 - Responsive, accessible homepage with custom art
 - Cloudflare Worker SSR deployment
+- Live globe presence over WebSockets + Durable Objects
 - Modern, mobile-friendly design
 
 ## 🚀 Project Structure
 
 ```
 /
-├── public/                # Static assets (images, .assetsignore, etc.)
+├── public/                           # Static assets (images, .assetsignore, etc.)
 ├── src/
+│   ├── worker-entry.ts               # Unified Worker entrypoint: Party routing first, Astro SSR fallback
+│   ├── server/
+│   │   └── index.ts                  # Partyserver Durable Object class: Globe
+│   ├── components/
+│   │   └── GlobeComponent.tsx        # WebSocket client + globe rendering
+│   ├── shared.ts                     # Shared websocket message/location types
 │   └── pages/
-│       └── index.astro    # Homepage (with ASCII art for curl)
+│       └── index.astro               # Homepage (with ASCII art for curl)
 ├── package.json
 ├── astro.config.mjs
 ├── wrangler.toml
 └── README.md
 ```
 
-## 🧑‍💻 Local Development
+## 🔌 Unified worker entrypoint (`src/worker-entry.ts`)
+
+`src/worker-entry.ts` is the Worker `main` configured in `wrangler.toml`.
+
+It runs in this order:
+1. Try Party routing first (`routePartykitRequest`) so websocket upgrades and `/parties/*` traffic are handled by Partyserver.
+2. If Partyserver does not handle the request, lazy-load `dist/_worker.js/index.js` and pass the request to Astro's SSR handler.
+
+This gives one Cloudflare Worker process for both realtime presence and normal page/API SSR.
+
+## 🧱 Durable Object binding (`Globe`)
+
+`wrangler.toml` binds the Durable Object used by Partyserver:
+
+- `[durable_objects]` binding name: `Globe`
+- class name: `Globe`
+- migration tag `v1` creates the sqlite-backed DO class (`new_sqlite_classes = ["Globe"]`)
+
+If this migration/binding is missing or out of sync in an environment, globe presence will not connect correctly.
+
+## 🌐 WebSocket client/server locations
+
+- **Client UI + websocket hookup:** `src/components/GlobeComponent.tsx`
+  - Uses `usePartySocket` with `party: "globe"` and `room: "default"`
+  - Receives `GlobeMessage`, updates marker map, and renders the rotating globe
+- **Server websocket logic (Partyserver/DO):** `src/server/index.ts`
+  - Exports `class Globe extends Server`
+  - On connect, stores location and broadcasts current presence map
+  - On close/error, rebroadcasts with disconnected client removed
+- **Shared protocol types:** `src/shared.ts`
+  - `Location` tuple
+  - `GlobeMessage` payload shape shared by client + server
+
+## 🧑‍💻 Local development and expected behavior
+
+Install and run Astro dev:
 
 ```sh
 pnpm install
 pnpm run dev
 ```
-Visit [localhost:4321](http://localhost:4321) in your browser.
+
+Visit [http://localhost:4321](http://localhost:4321).
+
+For full Worker + websocket/DO behavior locally (recommended when validating globe presence):
+
+```sh
+pnpm run build
+pnpm exec wrangler dev
+```
+
+Expected globe behavior:
+- A single open tab should show `1 person limiting their career outlooks.`
+- Opening additional tabs/browsers increases the count and adds globe markers.
+- Closing a tab should reduce the count shortly after disconnect.
+- If websocket connection is unavailable, the UI stays at `Connecting...`.
 
 ## 🏗️ Build & Deploy
 
 ```sh
 pnpm run build
-pnpm exec wrangler dev ./dist/_worker.js/index.js  # Local Cloudflare Worker preview
-pnpm exec wrangler deploy                          # Deploy to Cloudflare Workers
+pnpm exec wrangler dev ./dist/_worker.js/index.js  # Local Cloudflare Worker preview (SSR-only entry)
+pnpm exec wrangler deploy                           # Deploy to Cloudflare Workers
 ```
+
+## ⚠️ Common failures
+
+- **Wrong websocket path / routing bypassed:**
+  - Symptom: UI stuck on `Connecting...`
+  - Cause: requests are not reaching Party routes (for example, not using the unified `src/worker-entry.ts` path in Worker runtime)
+- **Missing Durable Object migration:**
+  - Symptom: websocket errors or DO class not found
+  - Cause: `[[migrations]]` for `Globe` not applied in target environment
+- **Stale Wrangler deploy:**
+  - Symptom: app code appears updated but websocket/protocol behavior is old or inconsistent
+  - Cause: latest worker bundle or migration state not deployed to the environment being tested
 
 ## 🖼️ Image Optimization
 - Place images in `public/` (use WebP/PNG for best performance)


### PR DESCRIPTION
### Motivation
- Clarify the unified Worker entrypoint and routing so realtime Partyserver websocket traffic and Astro SSR behavior are obvious to developers.
- Explain the Durable Object binding and migration for `Globe` so deployments and migrations don't break presence functionality.
- Surface where websocket client/server/shared code lives and how to run locally so contributors can validate globe presence reliably.

### Description
- Added documentation for `src/worker-entry.ts` describing that it routes Partyserver requests first via `routePartykitRequest` and falls back to lazy-loading Astro SSR from `dist/_worker.js/index.js`.
- Documented the Durable Object binding `Globe` and the `v1` migration entry that creates the sqlite-backed DO class from `wrangler.toml`.
- Listed the websocket code locations and roles for `src/components/GlobeComponent.tsx`, `src/server/index.ts`, and `src/shared.ts` and summarized their responsibilities.
- Added local run instructions (`pnpm run dev`, `pnpm run build`, `pnpm exec wrangler dev`) with expected globe presence behavior and a brief `Common failures` section covering wrong websocket path/routing, missing DO migration, and stale Wrangler deploys.

### Testing
- Docs-only change; no automated tests were required or run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a08cb368832289eac49107e34f89)