### PR TITLE
Normalize PUBLIC_PARTYKIT_HOST to restore globe websocket connections

### DIFF
--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -11,7 +11,31 @@ function App() {
   const ownId = useRef<string | null>(null);
 
   const partykitHost = import.meta.env.PUBLIC_PARTYKIT_HOST;
-  const normalizedHost = (partykitHost ?? "").replace(/^https?:\/\//, "").replace(/^wss?:\/\//, "").replace(/\/$/, "");
+  const normalizeHost = (value?: string) => {
+    if (!value) {
+      return "";
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return "";
+    }
+
+    try {
+      const withProtocol = /^(wss?|https?):\/\//i.test(trimmed)
+        ? trimmed
+        : `https://${trimmed}`;
+      const parsed = new URL(withProtocol);
+      return parsed.host;
+    } catch {
+      return trimmed
+        .replace(/^(wss?|https?):\/\//i, "")
+        .split("/")[0]
+        .trim();
+    }
+  };
+
+  const normalizedHost = normalizeHost(partykitHost);
   const socketHost = normalizedHost || window.location.host;
   const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
   const handleSocketConnected = () => setConnected(true);


### PR DESCRIPTION
### Motivation
- The globe presence UI could get stuck on `Connecting...` when `PUBLIC_PARTYKIT_HOST` was provided as a full URL or included path fragments, causing invalid PartySocket host values. 
- The intent is to accept either a bare host or a full URL for `PUBLIC_PARTYKIT_HOST` and fall back to the page host so the globe can connect to PartyKit reliably.

### Description
- Added a `normalizeHost` helper in `src/components/GlobeComponent.tsx` that trims the env value, accepts bare hosts or full URLs, and extracts a valid `host` portion. 
- Replaced the previous ad-hoc string replacements with the new `normalizeHost` call and preserved fallback to `window.location.host` when no usable env value is present. 
- This prevents leftover protocol/path fragments from being passed to `usePartySocket`, avoiding malformed websocket host values.

### Testing
- Ran `npm run build` and the build completed successfully (Astro/Vite client and server bundles produced). 
- Client bundle includes the updated `GlobeComponent` and the app builds without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a93ea9288322b0dcc58c02d238aa)