### PR TITLE
Make globe canvas responsive and use deterministic fallback coordinates

### DIFF
--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -4,6 +4,7 @@ import type { GlobeMessage, Location } from "../shared";
 
 function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [canvasSize, setCanvasSize] = useState(800);
   const [connected, setConnected] = useState(false);
   const [counter, setCounter] = useState(0);
   const positions = useRef<Map<string, Location>>(new Map());
@@ -64,6 +65,26 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const measure = () => {
+      const nextSize = Math.max(2, Math.round((canvas.offsetWidth || 400) * 2));
+      setCanvasSize((current) => (current === nextSize ? current : nextSize));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(canvas);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
     let phi = 0;
     const canvas = canvasRef.current;
 
@@ -75,8 +96,8 @@ function App() {
     
     const globe = createGlobe(canvas, {
       devicePixelRatio: 2,
-      width: 400 * 2,
-      height: 400 * 2,
+      width: canvasSize,
+      height: canvasSize,
       phi: 0,
       theta: 0,
       dark: 1,
@@ -107,7 +128,7 @@ function App() {
       console.log("[Globe] Destroying globe");
       globe.destroy();
     };
-  }, []);
+  }, [canvasSize]);
 
   const [clmTriggered, setClmTriggered] = useState(false);
   useEffect(() => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,10 +18,10 @@ export class Globe extends Server {
       return Number.isFinite(parsed) ? parsed : fallback;
     };
 
-    const randomLatitude = Math.random() * 180 - 90;
-    const randomLongitude = Math.random() * 360 - 180;
-    const latitude = parseCoordinate(ctx.request.cf?.latitude, randomLatitude);
-    const longitude = parseCoordinate(ctx.request.cf?.longitude, randomLongitude);
+    const fallbackLatitude = 20;
+    const fallbackLongitude = 0;
+    const latitude = parseCoordinate(ctx.request.cf?.latitude, fallbackLatitude);
+    const longitude = parseCoordinate(ctx.request.cf?.longitude, fallbackLongitude);
     const location: Location = [
       Math.max(-90, Math.min(90, latitude)),
       Math.max(-180, Math.min(180, longitude)),


### PR DESCRIPTION
### Motivation
- Ensure the globe rendering canvas resizes correctly with layout changes so the globe remains sharp and correctly sized. 
- Avoid reusing hard-coded/constant pixel sizes and keep the globe DPI-aware.
- Make server-side initial client location deterministic instead of using a random fallback for consistent behavior.

### Description
- Add `canvasSize` state and a `ResizeObserver` that measures `canvas.offsetWidth * 2` and updates the size via `setCanvasSize`. 
- Use `canvasSize` for the `createGlobe` `width` and `height` instead of hard-coded `400 * 2`, and add it to the globe effect dependency list so the globe reinitializes when size changes. 
- Ensure the `ResizeObserver` is disconnected during cleanup. 
- Replace random fallback coordinates on connection with fixed `fallbackLatitude = 20` and `fallbackLongitude = 0` and feed those through `parseCoordinate` to produce deterministic initial locations.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c19f45ec83228042fd38428670f3)