### PR TITLE
Refactor GlobeComponent PartySocket to same-origin and remove env host logic

### DIFF
--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -10,34 +10,10 @@ function App() {
   const positions = useRef<Map<string, Location>>(new Map());
   const ownId = useRef<string | null>(null);
 
-  const partykitHost = import.meta.env.PUBLIC_PARTYKIT_HOST;
-  const normalizeHost = (value?: string) => {
-    if (!value) {
-      return "";
-    }
-
-    const trimmed = value.trim();
-    if (!trimmed) {
-      return "";
-    }
-
-    try {
-      const withProtocol = /^(wss?|https?):\/\//i.test(trimmed)
-        ? trimmed
-        : `https://${trimmed}`;
-      const parsed = new URL(withProtocol);
-      return parsed.host;
-    } catch {
-      return trimmed
-        .replace(/^(wss?|https?):\/\//i, "")
-        .split("/")[0]
-        .trim();
-    }
-  };
-
-  const normalizedHost = normalizeHost(partykitHost);
-  const socketHost = normalizedHost || window.location.host;
+  const socketHost = window.location.host;
   const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const socketTarget = `${socketProtocol}://${socketHost}/parties/globe/default`;
+  console.debug("[PartySocket] Using same-origin socket target", socketTarget);
   const handleSocketConnected = () => setConnected(true);
 
   usePartySocket({
@@ -60,6 +36,7 @@ function App() {
     },
     onError(event) {
       console.error("[PartySocket] Connection error for globe/default", event);
+      setConnected(false);
     },
     onMessage(evt) {
       if (typeof evt.data !== "string") {


### PR DESCRIPTION
### Motivation
- Remove environment-dependent host resolution and normalization to enforce same-origin PartySocket connections for simpler deployment and improved security.
- Ensure `PartySocket` uses the current page's origin so the globe always connects back to its own host without relying on `PUBLIC_PARTYKIT_HOST`.
- Add a debug log to make it easy to troubleshoot the computed socket target in environments where routing or proxies are involved.

### Description
- Deleted `PUBLIC_PARTYKIT_HOST` reads and the `normalizeHost` helper from `src/components/GlobeComponent.tsx`.
- Set socket host and protocol from `window.location` via `const socketHost = window.location.host` and `const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws"`.
- Added `const socketTarget = `${socketProtocol}://${socketHost}/parties/globe/default`` and a single debug log `console.debug("[PartySocket] Using same-origin socket target", socketTarget)` for troubleshooting.
- Kept `path: "/parties"`, `party: "globe"`, and `room: "default"` unchanged and explicitly reset connection state with `setConnected(false)` in the `onError` handler.

### Testing
- Ran `npm run -s build`, which completed successfully and produced the client and server bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c7a589e8832294b51292a762b9b2)