### PR TITLE
Polish globe card status states and visual hierarchy

### DIFF
--- a/src/components/CardGlobe.astro
+++ b/src/components/CardGlobe.astro
@@ -1,6 +1,6 @@
 ---
 import GlobeComponent from './GlobeComponent.tsx';
 ---
-<div class="card globe-card">
+<div class="card globe-card globe-card--live" aria-label="Live globe activity card">
   <GlobeComponent client:only="react" />
 </div>

--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -5,7 +5,7 @@ import type { GlobeMessage, Location } from "../shared";
 
 function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [connected, setConnected] = useState(false);
+  const [connectionState, setConnectionState] = useState<"connecting" | "connected" | "retrying" | "error">("connecting");
   const [counter, setCounter] = useState(0);
   const positions = useRef<Map<string, Location>>(new Map());
   const ownId = useRef<string | null>(null);
@@ -38,7 +38,7 @@ function App() {
   const normalizedHost = normalizeHost(partykitHost);
   const socketHost = normalizedHost || window.location.host;
   const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-  const handleSocketConnected = () => setConnected(true);
+  const handleSocketConnected = () => setConnectionState("connected");
 
   usePartySocket({
     host: socketHost,
@@ -56,10 +56,11 @@ function App() {
         reason: event.reason,
         wasClean: event.wasClean,
       });
-      setConnected(false);
+      setConnectionState("retrying");
     },
     onError(event) {
       console.error("[PartySocket] Connection error for globe/default", event);
+      setConnectionState("error");
     },
     onMessage(evt) {
       if (typeof evt.data !== "string") {
@@ -160,16 +161,27 @@ function App() {
         </div>
       )}
 
-      <h1 className="globe-panel__title">
-        Who Else is Pulling a Career Limiting Maneuver?
-      </h1>
-      {connected ? (
+      <div className="globe-panel__copy" data-state={connectionState}>
+        <h1 className="globe-panel__title">
+          Who Else Is Pulling a Career-Limiting Maneuver?
+        </h1>
         <p className="globe-panel__subtitle">
-          <b className="globe-panel__counter">{counter}</b> {counter === 1 ? "person" : "people"} limiting their career outlooks.
+          {connectionState === "connected" ? (
+            <>
+              <span className="globe-panel__counter" role="status" aria-live="polite">
+                {counter} {counter === 1 ? "operator" : "operators"} online
+              </span>{" "}
+              currently limiting their career outlook.
+            </>
+          ) : connectionState === "error" ? (
+            "Connection failed. Retrying before this maneuver goes on your permanent record."
+          ) : connectionState === "retrying" ? (
+            "Signal dropped. Reconnecting to the career-limiting command center..."
+          ) : (
+            "Connecting to the career-limiting command center..."
+          )}
         </p>
-      ) : (
-        <p className="globe-panel__subtitle">Connecting...</p>
-      )}
+      </div>
 
       <div className="globe-panel__canvas-wrap">
         <canvas

--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -7,6 +7,7 @@ function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [connectionState, setConnectionState] = useState<"connecting" | "connected" | "retrying" | "error">("connecting");
   const [counter, setCounter] = useState(0);
+  const hasConnected = useRef(false);
   const positions = useRef<Map<string, Location>>(new Map());
   const ownId = useRef<string | null>(null);
 
@@ -38,7 +39,10 @@ function App() {
   const normalizedHost = normalizeHost(partykitHost);
   const socketHost = normalizedHost || window.location.host;
   const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-  const handleSocketConnected = () => setConnectionState("connected");
+  const handleSocketConnected = () => {
+    hasConnected.current = true;
+    setConnectionState("connected");
+  };
 
   usePartySocket({
     host: socketHost,
@@ -56,11 +60,14 @@ function App() {
         reason: event.reason,
         wasClean: event.wasClean,
       });
-      setConnectionState("retrying");
+      setConnectionState(hasConnected.current ? "retrying" : "connecting");
     },
     onError(event) {
       console.error("[PartySocket] Connection error for globe/default", event);
       setConnectionState("error");
+      window.setTimeout(() => {
+        setConnectionState((current) => (current === "error" ? "retrying" : current));
+      }, 1200);
     },
     onMessage(evt) {
       if (typeof evt.data !== "string") {
@@ -169,16 +176,16 @@ function App() {
           {connectionState === "connected" ? (
             <>
               <span className="globe-panel__counter" role="status" aria-live="polite">
-                {counter} {counter === 1 ? "operator" : "operators"} online
+                {counter} {counter === 1 ? "person" : "people"} live
               </span>{" "}
-              currently limiting their career outlook.
+              currently running career-limiting maneuvers.
             </>
           ) : connectionState === "error" ? (
-            "Connection failed. Retrying before this maneuver goes on your permanent record."
+            "Connection hiccup. Retrying before this becomes an official incident report."
           ) : connectionState === "retrying" ? (
-            "Signal dropped. Reconnecting to the career-limiting command center..."
+            "Signal dropped. Reconnecting to the career-limiting command center."
           ) : (
-            "Connecting to the career-limiting command center..."
+            "Connecting to the career-limiting command center."
           )}
         </p>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -240,6 +240,10 @@ header.site-header {
   min-height: 0;
 }
 
+.globe-card--live {
+  border-color: color-mix(in oklab, var(--accent) 12%, var(--border));
+}
+
 .globe-card > div {
   width: 100%;
   height: 100%;
@@ -255,23 +259,59 @@ header.site-header {
   align-items: center;
   text-align: center;
   padding: 20px;
-  gap: 8px;
+  gap: 10px;
+}
+
+.globe-panel__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.globe-panel__copy[data-state="connecting"],
+.globe-panel__copy[data-state="retrying"] {
+  opacity: 0.94;
+}
+
+.globe-panel__copy[data-state="error"] {
+  transform: translateY(1px);
 }
 
 .globe-panel__title {
   color: inherit;
   margin: 0;
-  font-size: 1.2rem;
-  line-height: 1.25;
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  text-wrap: balance;
 }
 
 .globe-panel__subtitle {
   color: var(--muted);
   margin: 0;
+  font-size: clamp(0.88rem, 1.2vw, 0.98rem);
+  line-height: 1.45;
+  min-height: 2.9em;
 }
 
 .globe-panel__counter {
-  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.62rem;
+  margin-right: 0.2rem;
+  border-radius: 999px;
+  font-weight: 650;
+  font-size: 0.84em;
+  letter-spacing: 0.02em;
+  color: #071018;
+  background: color-mix(in oklab, var(--accent) 75%, #fff);
+  vertical-align: baseline;
+}
+
+[data-theme="light"] .globe-panel__counter {
+  color: #0b172a;
 }
 
 .globe-panel__canvas-wrap {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -237,7 +237,7 @@ header.site-header {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 0;
+  min-height: 420px;
 }
 
 .globe-card--live {
@@ -253,6 +253,7 @@ header.site-header {
 
 .globe-panel {
   height: 100%;
+  min-height: 420px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -328,7 +329,7 @@ header.site-header {
 .globe-panel__canvas-wrap {
   width: 100%;
   flex: 1;
-  min-height: 0;
+  min-height: 240px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -359,12 +360,17 @@ header.site-header {
 
 @media (max-width: 640px) {
   .globe-card {
-    min-height: 0;
+    min-height: 340px;
   }
 
   .globe-panel {
     justify-content: flex-start;
     padding: 16px;
+    min-height: 340px;
+  }
+
+  .globe-panel__canvas-wrap {
+    min-height: 200px;
   }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -278,6 +278,12 @@ header.site-header {
   transform: translateY(1px);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .globe-panel__copy {
+    transition: none;
+  }
+}
+
 .globe-panel__title {
   color: inherit;
   margin: 0;
@@ -308,6 +314,11 @@ header.site-header {
   color: #071018;
   background: color-mix(in oklab, var(--accent) 75%, #fff);
   vertical-align: baseline;
+}
+
+.globe-panel__copy[data-state="retrying"] .globe-panel__counter,
+.globe-panel__copy[data-state="error"] .globe-panel__counter {
+  background: color-mix(in oklab, #f6d365 70%, #fff);
 }
 
 [data-theme="light"] .globe-panel__counter {


### PR DESCRIPTION
### Motivation
- Make the globe card present clearer runtime states (connecting/connected/error/retrying), improve readability, and keep the tongue-in-cheek copy but with consistent punctuation and tone.
- Improve accessibility and visual prominence of the live participant count while keeping the UI subtle and non-distracting.

### Description
- Replace boolean `connected` state with a typed union `connectionState` (`"connecting" | "connected" | "retrying" | "error"`) and map socket callbacks to those states in `src/components/GlobeComponent.tsx` so the UI can explicitly render each state.
- Standardize and tighten heading/subheading copy and punctuation; move title/subtitle into a `.globe-panel__copy` wrapper and emit the current state via `data-state` for styling-driven transitions in `GlobeComponent.tsx`.
- Convert the live count into an accessible pill/badge (`.globe-panel__counter`) with `role="status"` and `aria-live="polite"` and update copy to a consistent branded tone in `GlobeComponent.tsx`.
- Add a live-card modifier class and ARIA label to the wrapper (`globe-card--live`, `aria-label`) in `src/components/CardGlobe.astro` for clearer semantics and styling hooks.
- Update global styles in `src/styles/global.css` to tighten typography (`font-size`, `line-height`, letter spacing), add the counter badge styles, add subtle transitions for `.globe-panel__copy`, and a small live-card border treatment to signal activity.

### Testing
- Ran the production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c751068c8322ba8647f02b72da32)