### PR TITLE
Make globe canvas responsive, centered, and high‑DPI aware

### DIFF
--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -5,8 +5,10 @@ import type { GlobeMessage, Location } from "../shared";
 
 function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasWrapRef = useRef<HTMLDivElement>(null);
   const [connected, setConnected] = useState(false);
   const [counter, setCounter] = useState(0);
+  const [globeSize, setGlobeSize] = useState(0);
   const positions = useRef<Map<string, Location>>(new Map());
   const ownId = useRef<string | null>(null);
 
@@ -84,17 +86,44 @@ function App() {
   });
 
   useEffect(() => {
+    const wrap = canvasWrapRef.current;
+
+    if (!wrap) {
+      return;
+    }
+
+    const updateGlobeSize = () => {
+      const rect = wrap.getBoundingClientRect();
+      const nextSize = Math.max(0, Math.floor(Math.min(rect.width, rect.height)));
+      setGlobeSize((prevSize) => (prevSize === nextSize ? prevSize : nextSize));
+    };
+
+    updateGlobeSize();
+
+    const resizeObserver = new ResizeObserver(updateGlobeSize);
+    resizeObserver.observe(wrap);
+    window.addEventListener("resize", updateGlobeSize);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateGlobeSize);
+    };
+  }, []);
+
+  useEffect(() => {
     let phi = 0;
     const canvas = canvasRef.current;
+    const dpr = window.devicePixelRatio || 1;
+    const size = globeSize;
 
-    if (!canvas) {
+    if (!canvas || size <= 0) {
       return;
     }
 
     const globe = createGlobe(canvas, {
-      devicePixelRatio: 2,
-      width: 400 * 2,
-      height: 400 * 2,
+      devicePixelRatio: dpr,
+      width: size * dpr,
+      height: size * dpr,
       phi: 0,
       theta: 0,
       dark: 1,
@@ -119,7 +148,7 @@ function App() {
     return () => {
       globe.destroy();
     };
-  }, []);
+  }, [globeSize]);
 
   const [clmTriggered, setClmTriggered] = useState(false);
   useEffect(() => {
@@ -171,10 +200,11 @@ function App() {
         <p className="globe-panel__subtitle">Connecting...</p>
       )}
 
-      <div className="globe-panel__canvas-wrap">
+      <div ref={canvasWrapRef} className="globe-panel__canvas-wrap">
         <canvas
           ref={canvasRef}
           className="globe-panel__canvas"
+          style={{ width: globeSize, height: globeSize }}
         />
       </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -232,7 +232,7 @@ header.site-header {
 
 .globe-card {
   padding: 0;
-  overflow: hidden;
+  overflow: clip;
   border-radius: var(--radius);
   display: flex;
   align-items: center;
@@ -254,8 +254,9 @@ header.site-header {
   justify-content: center;
   align-items: center;
   text-align: center;
-  padding: 20px;
-  gap: 8px;
+  padding: clamp(14px, 2.2vw, 22px);
+  gap: clamp(8px, 1.5vw, 12px);
+  box-sizing: border-box;
 }
 
 .globe-panel__title {
@@ -281,11 +282,14 @@ header.site-header {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+  padding: clamp(6px, 1.2vw, 12px) 0;
 }
 
 .globe-panel__canvas {
   display: block;
-  width: min(100%, 400px);
+  max-width: min(100%, 440px);
+  max-height: min(100%, 440px);
   aspect-ratio: 1;
 }
 
@@ -312,8 +316,8 @@ header.site-header {
   }
 
   .globe-panel {
-    justify-content: flex-start;
-    padding: 16px;
+    justify-content: center;
+    padding: 14px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Replace the previous fixed Cobe rendering buffer with a size derived from the actual panel/container so the globe scales to available space. 
- Recreate/reconfigure the globe when the panel resizes so the rendered globe always remains square and centered. 
- Ensure high-DPI displays remain crisp by honoring the device pixel ratio when creating the Cobe render buffer. 
- Improve panel/canvas CSS so the globe is both horizontally and vertically centered and common breakpoints avoid overflow/clipping. 

### Description
- Added a `canvasWrapRef` and `globeSize` state in `src/components/GlobeComponent.tsx` and compute `globeSize` as `min(container.width, container.height)` using `ResizeObserver` and a window `resize` handler. 
- Reinitialize the Cobe globe whenever `globeSize` changes and pass `devicePixelRatio` with `width: size * dpr` and `height: size * dpr` so the render buffer matches CSS size for crisp high‑DPI output. 
- Apply the measured square size to the canvas DOM via inline `style={{ width: globeSize, height: globeSize }}` so layout and the render buffer are aligned. 
- Updated `src/styles/global.css` for globe layout: switched `overflow` to `clip` on `.globe-card`, used `clamp()` for `.globe-panel` paddings/gaps, added `overflow: hidden` and padding to `.globe-panel__canvas-wrap`, and constrained `.globe-panel__canvas` with `max-width`/`max-height` plus `aspect-ratio: 1`; also adjusted mobile overrides to keep the globe centered. 

### Testing
- Ran `npm run build` and the build completed successfully with no errors. 
- The project client/server build steps (Astro/Vite) finished without reported warnings that block the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c74fd27c8322b2e892a11aca4e77)