### PR TITLE
Fix globe rendering alignment and PartyServer local dev config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.2",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "wrangler dev --local",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -110,12 +110,13 @@ function App() {
       baseColor: [0.3, 0.3, 0.3],
       markerColor: [0.1, 0.8, 0.1],
       glowColor: [0.2, 0.2, 0.2],
+      scale: 1,
       markers: [],
       opacity: 0.7,
       onRender: (state) => {
-        state.markers = [...positions.current].map(([id, location]) => ({
-          location,
-          size: id === ownId.current ? 0.1 : 0.05,
+        state.markers = Array.from(positions.current, ([id, location]) => ({
+          location: [location[0], location[1]] as Location,
+          size: id === ownId.current ? 0.14 : 0.08,
         }));
         state.phi = phi;
         phi += 0.01;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "career-limiting-maneuver"
 main = "src/worker-entry.ts"
 compatibility_date = "2025-07-30"
-compatibility_flags = ["nodejs_compat"]
+compatibility_flags = ["nodejs_compat", "enable_ctx_exports"]
 upload_source_maps = true
 routes = [
   { pattern = "careerlimitingmaneuver.com", zone_name = "careerlimitingmaneuver.com", custom_domain = true }


### PR DESCRIPTION
### Motivation
- Fix globe marker visibility and positioning so connected users appear correctly on the globe and the globe is centered.
- Ensure local development exercises PartyServer Durable Objects and RPC behavior required by the server runtime.
- Normalize marker data shape so `cobe` receives markers in the expected array/tuple format.

### Description
- Added `enable_ctx_exports` to `wrangler.toml` compatibility flags to support Durable Object RPC behavior with `partyserver`.
- Switched the `dev` script in `package.json` from `astro dev` to `wrangler dev --local` so local development runs through the Worker/Durable Object path.
- Updated `src/components/GlobeComponent.tsx` to add `scale: 1`, convert marker generation to `Array.from(...)` with explicit `[lat, lng]` tuples, and slightly increase marker sizes for better visibility.

### Testing
- Ran `npm run build`, which completed successfully without errors.
- The Astro build produced client and server artifacts and finished the build steps successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c934d7a483229e8bf875bafb6bb1)