### PR TITLE
Globe: improve connection state, accessibility, copy, and styling

### DIFF
--- a/src/components/CardGlobe.astro
+++ b/src/components/CardGlobe.astro
@@ -1,6 +1,6 @@
 ---
 import GlobeComponent from './GlobeComponent.tsx';
 ---
-<div class="card globe-card">
+<div class="card globe-card globe-card--live" aria-label="Live globe activity card">
   <GlobeComponent client:only="react" />
 </div>

--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -5,8 +5,10 @@ import type { GlobeMessage, Location } from "../shared";
 
 function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [connected, setConnected] = useState(false);
+  const [connectionState, setConnectionState] = useState<"connecting" | "connected" | "retrying" | "error">("connecting");
   const [counter, setCounter] = useState(0);
+  const hasConnected = useRef(false);
+  const retryTimeoutRef = useRef<number | null>(null);
   const positions = useRef<Map<string, Location>>(new Map());
   const ownId = useRef<string | null>(null);
 
@@ -38,7 +40,14 @@ function App() {
   const normalizedHost = normalizeHost(partykitHost);
   const socketHost = normalizedHost || window.location.host;
   const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
-  const handleSocketConnected = () => setConnected(true);
+  const handleSocketConnected = () => {
+    if (retryTimeoutRef.current !== null) {
+      window.clearTimeout(retryTimeoutRef.current);
+      retryTimeoutRef.current = null;
+    }
+    hasConnected.current = true;
+    setConnectionState("connected");
+  };
 
   usePartySocket({
     host: socketHost,
@@ -56,10 +65,18 @@ function App() {
         reason: event.reason,
         wasClean: event.wasClean,
       });
-      setConnected(false);
+      setConnectionState(hasConnected.current ? "retrying" : "connecting");
     },
     onError(event) {
       console.error("[PartySocket] Connection error for globe/default", event);
+      setConnectionState("error");
+      if (retryTimeoutRef.current !== null) {
+        window.clearTimeout(retryTimeoutRef.current);
+      }
+      retryTimeoutRef.current = window.setTimeout(() => {
+        setConnectionState((current) => (current === "error" ? "retrying" : current));
+        retryTimeoutRef.current = null;
+      }, 1200);
     },
     onMessage(evt) {
       if (typeof evt.data !== "string") {
@@ -82,6 +99,14 @@ function App() {
       handleSocketConnected();
     },
   });
+
+  useEffect(() => {
+    return () => {
+      if (retryTimeoutRef.current !== null) {
+        window.clearTimeout(retryTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     let phi = 0;
@@ -160,16 +185,27 @@ function App() {
         </div>
       )}
 
-      <h1 className="globe-panel__title">
-        Who Else is Pulling a Career Limiting Maneuver?
-      </h1>
-      {connected ? (
+      <div className="globe-panel__copy" data-state={connectionState}>
+        <h1 className="globe-panel__title">
+          Who Else Is Pulling a Career-Limiting Maneuver?
+        </h1>
         <p className="globe-panel__subtitle">
-          <b className="globe-panel__counter">{counter}</b> {counter === 1 ? "person" : "people"} limiting their career outlooks.
+          {connectionState === "connected" ? (
+            <>
+              <span className="globe-panel__counter" role="status" aria-live="polite">
+                {counter} {counter === 1 ? "person" : "people"} live
+              </span>{" "}
+              currently running career-limiting maneuvers.
+            </>
+          ) : connectionState === "error" ? (
+            "Connection hiccup. Retrying before this becomes an official incident report."
+          ) : connectionState === "retrying" ? (
+            "Signal dropped. Reconnecting to the career-limiting command center."
+          ) : (
+            "Connecting to the career-limiting command center."
+          )}
         </p>
-      ) : (
-        <p className="globe-panel__subtitle">Connecting...</p>
-      )}
+      </div>
 
       <div className="globe-panel__canvas-wrap">
         <canvas

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -237,7 +237,11 @@ header.site-header {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 0;
+  min-height: 420px;
+}
+
+.globe-card--live {
+  border-color: color-mix(in oklab, var(--accent) 12%, var(--border));
 }
 
 .globe-card > div {
@@ -249,35 +253,83 @@ header.site-header {
 
 .globe-panel {
   height: 100%;
+  min-height: 420px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
   padding: 20px;
-  gap: 8px;
+  gap: 10px;
+}
+
+.globe-panel__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.globe-panel__copy[data-state="connecting"],
+.globe-panel__copy[data-state="retrying"] {
+  opacity: 0.94;
+}
+
+.globe-panel__copy[data-state="error"] {
+  transform: translateY(1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .globe-panel__copy {
+    transition: none;
+  }
 }
 
 .globe-panel__title {
   color: inherit;
   margin: 0;
-  font-size: 1.2rem;
-  line-height: 1.25;
+  font-size: clamp(1rem, 1.6vw, 1.25rem);
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  text-wrap: balance;
 }
 
 .globe-panel__subtitle {
   color: var(--muted);
   margin: 0;
+  font-size: clamp(0.88rem, 1.2vw, 0.98rem);
+  line-height: 1.45;
+  min-height: 2.9em;
 }
 
 .globe-panel__counter {
-  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.62rem;
+  margin-right: 0.2rem;
+  border-radius: 999px;
+  font-weight: 650;
+  font-size: 0.84em;
+  letter-spacing: 0.02em;
+  color: #071018;
+  background: color-mix(in oklab, var(--accent) 75%, #fff);
+  vertical-align: baseline;
+}
+
+.globe-panel__copy[data-state="retrying"] .globe-panel__counter,
+.globe-panel__copy[data-state="error"] .globe-panel__counter {
+  background: color-mix(in oklab, #f6d365 70%, #fff);
+}
+
+[data-theme="light"] .globe-panel__counter {
+  color: #0b172a;
 }
 
 .globe-panel__canvas-wrap {
   width: 100%;
   flex: 1;
-  min-height: 0;
+  min-height: 240px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -308,12 +360,17 @@ header.site-header {
 
 @media (max-width: 640px) {
   .globe-card {
-    min-height: 0;
+    min-height: 340px;
   }
 
   .globe-panel {
     justify-content: flex-start;
     padding: 16px;
+    min-height: 340px;
+  }
+
+  .globe-panel__canvas-wrap {
+    min-height: 200px;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Surface the globe's live connection status and make the UI more robust to transient socket errors.
- Improve accessibility for the live participant counter and provide clearer user-facing copy for connection states.
- Visually indicate when the globe is live and make the panel layout more consistent across viewports.

### Description
- Replaced the boolean `connected` with a typed `connectionState` (`"connecting" | "connected" | "retrying" | "error"`) and added `hasConnected` and `retryTimeoutRef` refs to manage reconnect behavior and debounce retries.
- Enhanced socket callbacks in `usePartySocket` to clear retry timers on success, set `connectionState` on `onClose`/`onError`, and schedule a retry transition; added cleanup to clear timers on unmount.
- Updated the UI in `GlobeComponent.tsx` to render connection-aware copy and an accessible live counter with `role="status"` and `aria-live="polite"`, and simplified the title/copy; added `aria-label` and `globe-card--live` class in `CardGlobe.astro`.
- Expanded `src/styles/global.css` with layout fixes and responsive `min-height` values, visual styling for `.globe-card--live`, counter styling, transition states for copy, and typography tweaks for better balance and spacing.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6c751068c8322ba8647f02b72da32)