### PR TITLE
[codex] Fix unified globe worker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,16 @@ If this migration/binding is missing or out of sync in an environment, globe pre
 
 ## 🧑‍💻 Local development and expected behavior
 
-Install and run Astro dev:
+Install dependencies, then run the unified worker locally:
 
 ```sh
 pnpm install
 pnpm run dev
 ```
 
-Visit [http://localhost:4321](http://localhost:4321).
+Visit [http://localhost:8787](http://localhost:8787).
 
-For full Worker + websocket/DO behavior locally (recommended when validating globe presence):
-
-```sh
-pnpm run build
-pnpm exec wrangler dev
-```
+`wrangler.toml` now runs `npm run build` before `wrangler dev` and `wrangler deploy`, so the Astro SSR bundle in `dist/_worker.js/index.js` stays in sync with the unified worker entrypoint.
 
 Expected globe behavior:
 - A single open tab should show `1 person limiting their career outlooks.`
@@ -89,8 +84,6 @@ Expected globe behavior:
 ## 🏗️ Build & Deploy
 
 ```sh
-pnpm run build
-pnpm exec wrangler dev ./dist/_worker.js/index.js  # Local Cloudflare Worker preview (SSR-only entry)
 pnpm exec wrangler deploy                           # Deploy to Cloudflare Workers
 ```
 
@@ -99,6 +92,9 @@ pnpm exec wrangler deploy                           # Deploy to Cloudflare Worke
 - **Wrong websocket path / routing bypassed:**
   - Symptom: UI stuck on `Connecting...`
   - Cause: requests are not reaching Party routes (for example, not using the unified `src/worker-entry.ts` path in Worker runtime)
+- **Stale or missing Astro SSR build:**
+  - Symptom: page or globe behavior differs between source files and the deployed/local worker
+  - Cause: `src/worker-entry.ts` imports `dist/_worker.js/index.js`, so `wrangler dev`/`deploy` must rebuild Astro first
 - **Missing Durable Object migration:**
   - Symptom: websocket errors or DO class not found
   - Cause: `[[migrations]]` for `Globe` not applied in target environment

--- a/src/components/GlobeComponent.tsx
+++ b/src/components/GlobeComponent.tsx
@@ -3,25 +3,24 @@ import createGlobe from "cobe";
 import usePartySocket from "partysocket/react";
 import type { GlobeMessage, Location } from "../shared";
 
+type GlobeMarker = {
+  location: Location;
+  size: number;
+};
+
 function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [connectionState, setConnectionState] = useState<"connecting" | "connected" | "retrying" | "error">("connecting");
   const [counter, setCounter] = useState(0);
   const hasConnected = useRef(false);
-  const positions = useRef<Map<string, Location>>(new Map());
-  const ownId = useRef<string | null>(null);
+  const positions = useRef<Map<string, GlobeMarker>>(new Map());
 
-  const socketHost = window.location.host;
-  const socketProtocol = window.location.protocol === "https:" ? "wss" : "ws";
   const handleSocketConnected = () => {
     hasConnected.current = true;
     setConnectionState("connected");
   };
 
   usePartySocket({
-    host: socketHost,
-    protocol: socketProtocol,
-    path: "/parties",
     room: "default",
     party: "globe",
     onOpen() {
@@ -56,9 +55,14 @@ function App() {
         return;
       }
 
-      ownId.current = message.id;
       positions.current = new Map(
-        Object.entries(message.globe).map(([id, location]) => [id, location]),
+        Object.entries(message.globe).map(([id, location]) => [
+          id,
+          {
+            location: [location[0], location[1]] as Location,
+            size: id === message.id ? 0.03 : 0.015,
+          },
+        ]),
       );
       setCounter(positions.current.size);
       handleSocketConnected();
@@ -66,44 +70,18 @@ function App() {
   });
 
   useEffect(() => {
-    const wrap = canvasWrapRef.current;
-
-    if (!wrap) {
-      return;
-    }
-
-    const updateGlobeSize = () => {
-      const rect = wrap.getBoundingClientRect();
-      const nextSize = Math.max(0, Math.floor(Math.min(rect.width, rect.height)));
-      setGlobeSize((prevSize) => (prevSize === nextSize ? prevSize : nextSize));
-    };
-
-    updateGlobeSize();
-
-    const resizeObserver = new ResizeObserver(updateGlobeSize);
-    resizeObserver.observe(wrap);
-    window.addEventListener("resize", updateGlobeSize);
-
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener("resize", updateGlobeSize);
-    };
-  }, []);
-
-  useEffect(() => {
     let phi = 0;
+    let animationFrame = 0;
     const canvas = canvasRef.current;
-    const dpr = window.devicePixelRatio || 1;
-    const size = globeSize;
 
-    if (!canvas || size <= 0) {
+    if (!canvas) {
       return;
     }
 
     const globe = createGlobe(canvas, {
-      devicePixelRatio: dpr,
-      width: size * dpr,
-      height: size * dpr,
+      devicePixelRatio: 2,
+      width: 400 * 2,
+      height: 400 * 2,
       phi: 0,
       theta: 0,
       dark: 1,
@@ -111,25 +89,29 @@ function App() {
       mapSamples: 16000,
       mapBrightness: 6,
       baseColor: [0.3, 0.3, 0.3],
-      markerColor: [0.1, 0.8, 0.1],
+      markerColor: [0.8, 0.1, 0.1],
       glowColor: [0.2, 0.2, 0.2],
-      scale: 1,
-      markers: [],
+      markerElevation: 0,
+      markers: [] as GlobeMarker[],
       opacity: 0.7,
-      onRender: (state) => {
-        state.markers = Array.from(positions.current, ([id, location]) => ({
-          location: [location[0], location[1]] as Location,
-          size: id === ownId.current ? 0.14 : 0.08,
-        }));
-        state.phi = phi;
-        phi += 0.01;
-      },
     });
 
+    const render = () => {
+      globe.update({
+        markers: [...positions.current.values()],
+        phi,
+      });
+      phi += 0.009;
+      animationFrame = window.requestAnimationFrame(render);
+    };
+
+    render();
+
     return () => {
+      window.cancelAnimationFrame(animationFrame);
       globe.destroy();
     };
-  }, [globeSize]);
+  }, []);
 
   const [clmTriggered, setClmTriggered] = useState(false);
   useEffect(() => {
@@ -180,7 +162,7 @@ function App() {
               <span className="globe-panel__counter" role="status" aria-live="polite">
                 {counter} {counter === 1 ? "person" : "people"} live
               </span>{" "}
-              currently running career-limiting maneuvers.
+              limiting their career outlooks.
             </>
           ) : connectionState === "error" ? (
             "Connection hiccup. Retrying before this becomes an official incident report."
@@ -192,11 +174,11 @@ function App() {
         </p>
       </div>
 
-      <div ref={canvasWrapRef} className="globe-panel__canvas-wrap">
+      <div className="globe-panel__canvas-wrap">
         <canvas
           ref={canvasRef}
           className="globe-panel__canvas"
-          style={{ width: globeSize, height: globeSize }}
+          style={{ width: 400, height: 400, maxWidth: "100%", aspectRatio: 1 }}
         />
       </div>
     </div>

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,7 +43,10 @@ export class Globe extends Server {
       }
 
       if (connection.state?.location) {
-        globe[connection.id] = connection.state.location;
+        globe[connection.id] = [
+          connection.state.location[0],
+          connection.state.location[1],
+        ];
       }
     }
 

--- a/src/worker-entry.ts
+++ b/src/worker-entry.ts
@@ -5,10 +5,7 @@ export { Globe } from "./server/index";
 type MessageListener = (event: { data: unknown }) => void;
 
 const runtimeGlobal = globalThis as typeof globalThis & {
-  MessageChannel?: new () => {
-    port1: unknown;
-    port2: unknown;
-  };
+  MessageChannel?: unknown;
 };
 
 if (typeof runtimeGlobal.MessageChannel === "undefined") {
@@ -70,7 +67,7 @@ if (typeof runtimeGlobal.MessageChannel === "undefined") {
       this.port1.setTarget(this.port2);
       this.port2.setTarget(this.port1);
     }
-  };
+  } as unknown as typeof MessageChannel;
 }
 
 type WorkerModule = {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -14,6 +14,10 @@ enabled = true
 directory = "./dist"
 binding = "ASSETS"
 
+[build]
+command = "npm run build"
+watch_dir = ["src", "public", "astro.config.mjs"]
+
 [ai]
 binding = "AI"
 


### PR DESCRIPTION
## What changed

This PR fixes the multiplayer globe after merging it into the unified Astro + Cloudflare Worker app.

It updates the globe client to use the working unified snapshot message format, restores same-origin PartySocket routing for the Durable Object websocket, and simplifies the globe rendering path so the globe position and marker rendering behave correctly inside the card layout.

It also adds a Wrangler build step so `wrangler dev` and `wrangler deploy` rebuild the Astro worker bundle before `src/worker-entry.ts` imports `dist/_worker.js/index.js`.

## Why

The integrated globe had a few separate regressions:

- the React client referenced missing canvas sizing state/refs
- the PartySocket client was configured with an invalid `path` override, so websocket traffic never reached `/parties/globe/default`
- the merged globe rendering path diverged from the working template behavior, which caused the globe not to render and the marker appearance to be off
- Wrangler was depending on a manually fresh Astro build even though the unified worker imports the built SSR bundle at runtime

## Impact

- the globe renders again locally in the unified worker
- websocket presence connects through the unified Worker + Durable Object setup
- the live text now reads `limiting their career outlooks.`
- local Cloudflare development matches the actual worker entry flow more closely

## Validation

- `npm run build`
- local `wrangler dev --local` verification from the user, including `101 Switching Protocols` on `/parties/globe/default`
